### PR TITLE
Highlight outdated LEGAL_IMPRINT

### DIFF
--- a/LEGAL_IMPRINT.md
+++ b/LEGAL_IMPRINT.md
@@ -1,9 +1,8 @@
 # Legal Imprint
 
+# :warning: Please note that the content of this file will not be maintained any more. Please use the link provided below.
+
 **Please find the current provider information with this [Link](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md).** 
-
-**The below content will not be maintained any more.**
-
 
 This file contains Legal Disclaimers for linking in Issues and Pull Requests.
 


### PR DESCRIPTION
Currently the notice that the LEGAL_IMPRINT.md is outdated might easily be overlooked. Tried to highlight that. 