### PR TITLE
Update CONTRIBUTORS_LICENSE_AGREEMENT.md

### DIFF
--- a/CONTRIBUTORS_LICENSE_AGREEMENT.md
+++ b/CONTRIBUTORS_LICENSE_AGREEMENT.md
@@ -1,8 +1,6 @@
 # Contributors License Agreement 
 Version 1.2, proprietary document Mercedes-Benz Group.
 
->**Contributions** to a **Mercedes-Benz Mobile SDK (MBSDK) repository**: please sign the Mercedes-Benz Mobile SDK CLA "[2019-09-11_Daimler_FOSS_CLA_Mercedes-Benz_Mobile_SDK.pdf](./cla/2019-09-11_Daimler_FOSS_CLA_Mercedes-Benz_Mobile_SDK.pdf)" and send a scan of the CLA to cla-mbition@mercedes-benz.com.
->
 >**Contributions** to any **Mercedes-Benz Tech Innovation repository**: please sign the Mercedes-Benz Tech Innovation CLA "[2022-04-25_MB_FOSS_CLA_MBTI.pdf](./cla/2022-04-25_MB_FOSS_CLA_MBTI.pdf)" and send a scan of the CLA to CLA-mbti@mercedes-benz.com.
  
 ## 0 CLA Parties


### PR DESCRIPTION
removed Mercedes-Benz Mobile SDK (MBSDK) from CLA, because there are no actively maintained projects. If the want to start with the initiative again, we can reset this change